### PR TITLE
Refine combat specs with deterministic AI and networking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ We follow a **spec‑first** workflow (Dex loop): research → plan → implemen
 
 1. **Spawn in Hub** → socialize, mirror, check progress.  
 2. **Prepare** → choose class/abilities, buy upgrades with run currency.  
-3. **Group Elevator** → 3–5s countdown captures the **participant set**.  
+3. **Group Elevator** → 3–5 s countdown captures the **participant set**.
 4. **Dungeon Run** → modular rooms, enemies, loot, materials, XP.  
 5. **Return to Hub** → bank rewards, upgrade, repeat.
 
@@ -24,12 +24,12 @@ We follow a **spec‑first** workflow (Dex loop): research → plan → implemen
 
 - **Simulation vs View**: strict split. Simulation = combat logic, HP, timers, AI; View = VFX, audio, ragdolls.
 - **Combat Feel**: animation‑gated trigger hitboxes; **0 GC/frame**; input→hit feedback **< 80 ms**.
-- **AI Decisions**: **10 Hz** fixed cadence via `CombatLoop`; distance² thresholds (CHASE_DIST²=**25**, ATTACK_DIST²=**4**), **FOVcos≈0.1736** (160° FOV), **LOS** raycast **every 3rd tick** on `Environment` layer.
+- **AI Decisions**: AI 10 Hz; CHASE_DIST²=25; ATTACK_DIST²=4; FOVcos≈0.1736; LOS every 3rd tick on `Environment`.
 - **Movement Model**: **NavMesh‑free at runtime** (procedural dungeon). Enemies use a **stitched waypoint graph** per tile; light **A*** only when target tile changes; otherwise steer‑to‑node. If LOS is clear, steer directly.
 - **Authority**: single **`GameAuthority`** owned by instance master manages `enemyHp[]`/`enemyAlive[]`. Players send compact hit requests.
 - **Throttling & Sync**: ≤ **8 hit requests/s/player** (125 ms window). Enemy HP diffs serialized at **2 Hz** and on death. Zone enter/exit debounced **200 ms**.
 - **Presence/Run Semantics**: only one dungeon run active. Participant set drives state while `participantsInDungeon > 0`. Late joiners stay hub‑side.
-- **Failover**: Instance master leaves → transfer to lowest playerId; RequestSerialization()
+- **Failover**: If the instance master leaves, authority transfers to the lowest `playerId`, then `RequestSerialization()` is called immediately.
 
 **Performance Budgets (Quest‑like target):** Scripts ≤ **1.5 ms**, Physics ≤ **2.0 ms**, Draw calls **< 90** (mirror off).
 
@@ -58,9 +58,13 @@ We follow a **spec‑first** workflow (Dex loop): research → plan → implemen
 **Milestones** (from plan): windows → weapon/damageable → CombatLoop (60 Hz) → AI (10 Hz) → waypoint stitcher → GameAuthority + throttling/failover → pooled spawner → visualizers/tests → Scripts ≤1.5 ms; Physics ≤2.0 ms; Draw calls < 90; 0 GC/frame.
 
 **Acceptance (must pass):**
-- **Latency**: input→hit FX **< 80 ms**  
-- **Determinism**: dummy target → identical hit counts across **10 runs**  
-- **Load**: 32 players × 10 active enemies (≈ 320 entities) → frame **< 16 ms**, **0 GC spikes**  
+- Scripts **≤ 1.5 ms** (Quest-like target)
+- Physics **≤ 2.0 ms** (Quest-like target)
+- Draw calls **< 90** in dungeon (mirror off)
+- **0 GC allocations per frame** in combat scenes
+- **Latency**: input→hit FX **< 80 ms**
+- **Determinism**: dummy target → identical hit counts across **10 runs**
+- **Load**: 32 players × 10 active enemies (≈ 320 entities) → frame **< 16 ms**, **0 GC spikes**
 - **Networking**: throttle respected (≤8/s/player); HP diffs at **~2 Hz**; seamless **owner failover** to lowest `playerId`
 
 ---


### PR DESCRIPTION
## Summary
- clarify the AI sensing cadence, navmesh-free movement description, run participation debounce, and data-first schemas in `research.md`
- sync `plan.md` with research updates, including success criteria, networking tolerances, and a tuning guide for key combat numbers
- surface the critical AI, failover, and acceptance targets in the repository `readme.md`

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c88a753e708321a8e83cc3ef19c4f1