### PR TITLE
Docs normalization: Lumen/Tablet + device roles + EconomySpec + README scope

### DIFF
--- a/Design Documents/lore.md
+++ b/Design Documents/lore.md
@@ -27,6 +27,19 @@
 - Shows **Lumen**, **Kill Ledger** (by enemy type), **Clearance** rank, and simple GA/Caretaker text.
 - **Owner-locked** when docked (no theft), **visible to all** for immersion.
 
+## Hub devices at a glance
+
+| Device           | Role (source of truth) |
+|------------------|------------------------|
+| Save Terminal    | First-time registration and initial persistence setup. |
+| Protocol Dais    | Post-run imprint/debrief station beside the Amnion. |
+| Amnion Vat       | Resuscitation if sufficient **Lumen** is banked. |
+| Printer          | Craft and upgrade gear. |
+| Locker           | Store crafted gear for later runs. |
+| Pedestal (x32)   | Diegetic tablet “parking” slots for persistence affordance. |
+| Descent Core     | Single-terminal elevator to dungeon. Hub has **no access doors**; only the elevator has a sealing shutter. |
+
+
 ## Arrival & Registration (First-Time or After a Wipe)
 - **Spawn:** the **malfunctioning teleporter bay**—a sputtering portal on the Hub’s edge.
 - A **depowered tablet** lies on the floor.
@@ -40,8 +53,8 @@
 
 ## Amnion Reserve (Lumen-Backed Recovery)
 - The **Amnion Vat** can pull you back from catastrophic injury **only if** you have enough **Amnion Reserve (AR)**—Lumen you’ve **deposited in the Hub** for resuscitation. Deposits are **one-way**.
-- **Resuscitation costs (defaults):** SURVEY **6**, BREACH **8**, SIEGE **10**, COLLAPSE **12**.
-- Tablet and elevator show your **AR** and a recommended buffer (≈ **2×** tier cost).
+- **Resuscitation costs (defaults):** See [EconomySpec](./research.md#economyspec) (source of truth).
+- Tablet and elevator show your **AR** and a recommended buffer (see [EconomySpec](./research.md#economyspec) for current tuning).
 
 **Death outcomes**
 - **Insured (AR ≥ cost):** tablet emits recall pulse → Amnion **debits AR** and restores you at the vat.
@@ -51,7 +64,7 @@
 
 ## Progression Without Perks — Clearance & Depth
 - **Clearance** is access authority earned by action (shared credit): enemy defeats, objective beats, **layer clears**.
-- **Bank** Clearance only by **Imprint** (Debrief at Save Terminal → Imprint at Amnion).
+- **Bank** Clearance only by **Imprint** (Debrief at the Protocol Dais → Imprint at the Amnion).
 - Clearance **gates** pressure tiers; it never buffs stats or discounts costs.
 
 ### Pressure Tiers (instance setting)
@@ -63,17 +76,19 @@
 Higher tiers increase **world pressure** (denser spawns, sturdier enemies, richer reservoir yields, miniboss guarantees). Players do **not** gain power from Clearance; only access.
 
 ## The Hub Devices (Core Interfaces)
-- **Save Terminal (Registration / Debrief):** create save; show **Run Summary** (kills by type, layers cleared, objectives, Clearance gained) before Imprint.
-- **Amnion Vat (Recovery & Banking):** deposit Lumen to **AR**; recall on death if AR ≥ cost.
+- **Save Terminal (Registration):** create your save profile and link the tablet for initial persistence.
+- **Protocol Dais (Debrief):** aggregate the run summary beside the Amnion and handle post-run imprint.
+- **Amnion Vat (Recovery & Banking):** deposit Lumen to **AR**; recall on death if AR ≥ cost (see [EconomySpec](./research.md#economyspec)).
 - **Constructor (Printer):** convert Lumen into **matter** (weapons/upgrades).
 - **Locker:** stores crafted gear for this save.
+- **Pedestal array (x32):** tablet parking slots for persistence affordance.
 - **Anodyne Crucible:** hub healing for Lumen.
 - **GA Ledger Terminal:** optional Lumen→Scrip exchange.
 
 ## Elevator — Descent Core (Single Terminal)
 - One **central Key Dock**. Whoever docks becomes **Conductor** for that cycle, selects a **pressure tier** allowed by their **banked Clearance**, then launches.
 - A **REQUEST CONTROL** plate lets a higher-rank player politely ask for the dock—no forced ejects.
-- Launch arms for ~2 s; doors seal; the tablet **auto-ejects** back to the owner.
+- Launch arms for ~2 s; doors seal; the tablet **auto-ejects** back to the owner. The hub room has no access doors; only the elevator mechanism uses a sealing shutter.
 
 Panel copy:
 - `Dock key to select pressure.`
@@ -107,15 +122,16 @@ Panel copy:
 2) **Prep:** craft/print, heal, **deposit Lumen to AR**.  
 3) **Descent Core:** dock tablet → tier (by banked Clearance) → launch.  
 4) **In layers:** harvest **Lumen** (taps/vats), fight, open shortcuts, find **Uplink**.  
-5) **Return:** **Debrief** → **Imprint** (bank Clearance & ledger) → print/trade/deposit.  
+5) **Return:** **Protocol Dais (Debrief)** → **Imprint at Amnion** (bank Clearance & ledger) → print/trade/deposit.  
 6) **Death:**  
    - **Insured:** recall (AR debited), continue.  
    - **Uninsured:** recall denied → **world save wiped** → back to teleporter, start again.
 
 ## Glossary
 - **Lumen:** white-blue energy gel used as currency.  
-- **Tablet (Key):** visible identity device; owner-locked when docked.  
-- **Save Terminal:** create save; debrief runs.  
+- **Tablet (Key):** visible identity device; owner-locked when docked.
+- **Protocol Dais:** post-run debrief station beside the Amnion (Imprint).  
+- **Save Terminal:** handle first-time registration and save creation only.  
 - **Amnion Vat / Amnion Reserve (AR):** Lumen-backed resuscitation bank and recall.  
 - **Constructor (Printer):** converts Lumen into matter (gear).  
 - **Locker:** stores crafted gear (per save).  

--- a/Design Documents/plan.md
+++ b/Design Documents/plan.md
@@ -2,6 +2,19 @@
 
 This plan is **1:1 aligned** with the latest `research.md` (Refined) for L2.005‑GA. All thresholds, states, and budgets here exactly match the research doc to avoid drift.
 
+## Hub devices at a glance
+
+| Device           | Role (source of truth) |
+|------------------|------------------------|
+| Save Terminal    | First-time registration and initial persistence setup. |
+| Protocol Dais    | Post-run imprint/debrief station beside the Amnion. |
+| Amnion Vat       | Resuscitation if sufficient **Lumen** is banked. |
+| Printer          | Craft and upgrade gear. |
+| Locker           | Store crafted gear for later runs. |
+| Pedestal (x32)   | Diegetic tablet “parking” slots for persistence affordance. |
+| Descent Core     | Single-terminal elevator to dungeon. Hub has **no access doors**; only the elevator has a sealing shutter. |
+
+
 ---
 
 ## 0) Success Criteria (must‑meet)
@@ -286,9 +299,9 @@ Exact Implementation Changes (addendum):
 ## Ranged Combat — Plan & Acceptance
 
 **Plan**
-- Add `RangedWeaponSpec` and `BackpackChargerSpec` assets; optional `WeaponQualitySpec`.
+- Add `RangedWeaponSpec` and `TabletChargerSpec` assets; optional `WeaponQualitySpec`.
 - Implement **manual hold charging**: proximity ≤ `holdRadiusM=0.25 m`, tick at `10 Hz`, one shot added per `chargeTimeSec`.
-- Shots live in the weapon **magazine**; firing consumes from magazine; **no auto siphon** from backpack mid-fight.
+- Shots live in the weapon **magazine**; firing consumes from magazine; **no auto siphon** from tablet mid-fight.
 - Fire path: authority-validated **single-ray hitscan**; long `cooldownSec`; magazine capacity obeys `capacity` or `qualityTier` mapping.
 - Networking throttles: `charge ≤ 10/s/player`, `shot ≤ 20/s/player`; diffs ≈ **2 Hz**; dedupe keys as in research.
 
@@ -296,7 +309,7 @@ Exact Implementation Changes (addendum):
 - Charge completes in `chargeTimeSec ± 0.1 s` when held within `0.25 m`; progress ticks at **10 Hz**.
 - Weapon capacity respects spec/quality (e.g., tiered: 1/2/3 shots).
 - Cannot fire during `cooldownSec`; cannot overfill magazine; cannot auto-charge.
-- Ammo correctness: Aether is decremented only on **charge completion**; never double-charged.
+- Ammo correctness: Lumen is decremented only on **charge completion**; never double-charged.
 - Perf under 8 players charging/firing: scripts ≤ **1.5 ms**, **0-GC**; state diffs **~2 Hz**; draw calls remain < 90.
 
 ## 11) Opt-in Leaderboard (This World Only)
@@ -415,13 +428,13 @@ Tiers never alter player stats or Lumen costs; they only change world pressure a
 
 ### Success Criteria
 - Players can finish a run, read Debrief, **Imprint once**, and unlock higher tiers via banked Clearance.
-- Lumen economy remains intact and unchanged; 32-player hub stays performant and readable.
+- Lumen economy remains intact and unchanged (see [EconomySpec](./research.md#economyspec)); 32-player hub stays performant and readable.
 
 
 
 ## 13) Elevator — Descent Core (Single Terminal, Tablet-Keyed)
 
-**Intent:** Make the elevator the ritual that starts every descent. One **central terminal** in the elevator (the **Descent Core**) accepts exactly one tablet at a time (“Key Dock”). The docked tablet’s **owner** becomes the **Conductor** for that cycle. Tiers (SURVEY/BREACH/SIEGE/COLLAPSE) unlock based on the **owner’s banked Clearance rank**. Everyone can see the docked tablet and tier choice; only the **owner** can interact, preventing theft.
+**Intent:** Make the elevator the ritual that starts every descent. One **central terminal** in the elevator (the **Descent Core**) accepts exactly one tablet at a time (“Key Dock”). The docked tablet’s **owner** becomes the **Conductor** for that cycle. Tiers (SURVEY/BREACH/SIEGE/COLLAPSE) unlock based on the **owner’s banked Clearance rank**. Everyone can see the docked tablet and tier choice; only the **owner** can interact, preventing theft. The hub room has no access doors; only the elevator mechanism uses a sealing shutter.
 
 ### Device Identity & Presence
 - **Descent Core (Key Dock + Tier Panel):** Waist-height **Key Dock** in the center ring; a tall **Tier Panel** above the doors shows the current selection and locks.

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,26 @@ This repository hosts the living specs for a high‑performance, VR‑first **hu
 
 We follow a **spec‑first** workflow (Dex loop): research → plan → implement → compact. Code only begins once specs are green.
 
+## Hub devices at a glance
+
+| Device           | Role (source of truth) |
+|------------------|------------------------|
+| Save Terminal    | First-time registration and initial persistence setup. |
+| Protocol Dais    | Post-run imprint/debrief station beside the Amnion. |
+| Amnion Vat       | Resuscitation if sufficient **Lumen** is banked. |
+| Printer          | Craft and upgrade gear. |
+| Locker           | Store crafted gear for later runs. |
+| Pedestal (x32)   | Diegetic tablet “parking” slots for persistence affordance. |
+| Descent Core     | Single-terminal elevator to dungeon. Hub has **no access doors**; only the elevator has a sealing shutter. |
+
+
 ---
 
 ## 🎮 Core Loop
 
 1. **Spawn in Hub** → socialize, mirror, check progress.  
-2. **Prepare** → choose class/abilities, buy upgrades with run currency.  
-3. **Group Elevator** → 3–5 s countdown captures the **participant set**.
+2. **Prepare** → bank Lumen, craft/upgrade gear at the Printer, and check your loadout.  
+3. **Group Elevator** → 3–5 s countdown captures the **participant set**. The hub room has no access doors; only the elevator mechanism uses a sealing shutter.
 4. **Dungeon Run** → modular rooms, enemies, loot, materials, XP.  
 5. **Return to Hub** → bank rewards, upgrade, repeat.
 
@@ -26,7 +39,7 @@ We follow a **spec‑first** workflow (Dex loop): research → plan → implemen
 - **Combat Feel**: animation‑gated trigger hitboxes; **0 GC/frame**; input→hit feedback **< 80 ms**.
 - **AI Decisions**: AI 10 Hz; CHASE_DIST²=25; ATTACK_DIST²=4; FOVcos≈0.1736; LOS every 3rd tick on `Environment`.
 - **Movement Model**: **NavMesh‑free at runtime** (procedural dungeon). Enemies use a **stitched waypoint graph** per tile; light **A*** only when target tile changes; otherwise steer‑to‑node. If LOS is clear, steer directly.
-- **Ranged:** Aether-charged by **manual hold** from the backpack; weapons have **multi-shot magazines** (by quality). Hitscan, single shot, long cooldown.
+- **Ranged:** Lumen-charged by **manual hold** from the tablet; weapons have **multi-shot magazines** (by quality). Hitscan, single shot, long cooldown.
 - **Authority**: single **`GameAuthority`** owned by instance master manages `enemyHp[]`/`enemyAlive[]`. Players send compact hit requests.
 - **Throttling & Sync**: ≤ **8 hit requests/s/player** (125 ms window). Enemy HP diffs serialized at **2 Hz** and on death. Zone enter/exit debounced **200 ms**.
 - **Presence/Run Semantics**: only one dungeon run active. Participant set drives state while `participantsInDungeon > 0`. Late joiners stay hub‑side.


### PR DESCRIPTION
## Summary
- normalize energy/device terminology to Lumen/Tablet and update related spec field names across lore, plan, research, and README
- align Save Terminal, Protocol Dais, and Pedestal naming while adding the shared hub devices table and elevator shutter note to each doc
- introduce the EconomySpec table in research.md as the numeric source of truth and link other docs/README scope updates back to it

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cad5cd0dac83218345757affb6cc8c