### PR TITLE
Docs: Make portal navgraph (BFS) the primary navigation model

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ We follow a **spec‑first** workflow (Dex loop): research → plan → implemen
 - **Simulation vs View**: strict split. Simulation = combat logic, HP, timers, AI; View = VFX, audio, ragdolls.
 - **Combat Feel**: animation‑gated trigger hitboxes; **0 GC/frame**; input→hit feedback **< 80 ms**.
 - **AI Decisions**: AI 10 Hz; CHASE_DIST²=25; ATTACK_DIST²=4; FOVcos≈0.1736; LOS every 3rd tick on `Environment`.
-- **Movement Model**: **NavMesh‑free at runtime** (procedural dungeon). Enemies use a **stitched waypoint graph** per tile; light **A*** only when target tile changes; otherwise steer‑to‑node. If LOS is clear, steer directly.
+- **Movement Model**: **NavMesh-free at runtime**. Tiles use local `WaypointGroup` waypoints; cross-tile routing uses a **global portal navgraph** (doorways only) with **BFS** (fewest-door path) or an optional precomputed `nextHop` table. Owner-only AI ticks at **50–100 ms**; zero allocations in hot paths.
 - **Ranged:** Lumen-charged by **manual hold** from the tablet; weapons have **multi-shot magazines** (by quality). Hitscan, single shot, long cooldown.
 - **Authority**: single **`GameAuthority`** owned by instance master manages `enemyHp[]`/`enemyAlive[]`. Players send compact hit requests.
 - **Throttling & Sync**: ≤ **8 hit requests/s/player** (125 ms window). Enemy HP diffs serialized at **2 Hz** and on death. Zone enter/exit debounced **200 ms**.


### PR DESCRIPTION
Promote portal-based global navgraph to primary model; add specs (`DungeonGraphManager`, `EnemyNavigator`), mention edge flags & enemy capability masks, optional `nextHop` precompute, owner-only tick policy; update README Movement Model; keep Save Terminal = registration+debrief and Amnion = recovery only; no Dais/Pedestal.

------
https://chatgpt.com/codex/tasks/task_e_68cb69da7b3883219d979237b33165b2