### PR TITLE
Align helper usage with router and pool APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,12 @@
 - You MUST follow every guardrail. If a requested change conflicts, refuse and propose a compliant alternative.
 - After edits, run a repo-wide validation: search for forbidden patterns and print matches.
 
-**MVP Task Note:** Always read and follow CLAUDE.md before each task; adhere to repo paths shown in the VS Code screenshot; never create new folders or rename files for MVP tasks; prefer minimal [UdonSynced] and explicit save via PersistenceManager.
+-**MVP Task Note:** Always read and follow CLAUDE.md before each task; adhere to repo paths shown in the VS Code screenshot; never create new folders or rename files for MVP tasks; prefer minimal [UdonSynced] and explicit save via PersistenceManager.
+
+## Guardrails/Coding Rules
+API-FIRST RULE — never invent helper methods. Before calling any method on project helpers (AudioRouter, FXRouter, SimpleObjectPool, NetworkedToggle, WeaponBase), open the helper’s source and copy the exact signature. If a method doesn’t exist, adapt to an existing one or add a tiny wrapper inside the helper with a one-line comment explaining why.
+Override Safety: Only write override when the base class declares that exact signature as virtual or abstract. Paste the base signature above your override and cite the file/line.
+VRC Ownership: Always call Networking.SetOwner(VRCPlayerApi player, GameObject obj) with (Networking.LocalPlayer, target) — reversed order is a build-fail.
 
 # Claude Code — UdonSharp Project Staging (VRChat)
 
@@ -73,6 +78,7 @@ var pos = Camera.main.transform.position;
 1. No `Camera.main` in any `Assets/` or `scripts/` C# files.
 2. Use LocalPlayer head tracking for player view data.
 3. Keep other UdonSharp guardrails: no `GetComponent(typeof(T))` on user types; no multidimensional arrays `T[,]`; correct VRChat SDK namespaces.
+4. For every helper call added/edited, include a one-line comment citing the source file and method signature (e.g., `// FXRouter.PlayAt(int id, Vector3 pos)`). If you can’t cite it, don’t commit.
 
 ### Override Guardrail — No Non-Existent Base Methods
 

--- a/scripts/Enemies/DropTable.cs
+++ b/scripts/Enemies/DropTable.cs
@@ -53,17 +53,17 @@ public class DropTable : UdonSharpBehaviour
         Vector3 spawnPos = basePosition + offset;
 
         // Spawn item
-        GameObject dropInstance;
+        GameObject dropInstance = null;
         if (itemPool != null)
         {
-            dropInstance = itemPool.GetFromPool();
-            if (dropInstance != null)
+            if (itemPool.TrySpawn(out dropInstance)) // SimpleObjectPool.TrySpawn(out GameObject instance)
             {
                 dropInstance.transform.position = spawnPos;
                 dropInstance.SetActive(true);
             }
         }
-        else
+
+        if (dropInstance == null)
         {
             dropInstance = VRCInstantiate(selectedPrefab.gameObject);
             if (dropInstance != null)

--- a/scripts/Enemies/EnemySpawner.cs
+++ b/scripts/Enemies/EnemySpawner.cs
@@ -82,7 +82,7 @@ public class EnemySpawner : UdonSharpBehaviour
             enemy.transform.rotation = spawnPoint.rotation;
 
             // Assign ownership to spawner
-            Networking.SetOwner(enemy, Networking.LocalPlayer);
+            Networking.SetOwner(Networking.LocalPlayer, enemy);
 
             currentAliveCount++;
         }

--- a/scripts/World/BankTerminal.cs
+++ b/scripts/World/BankTerminal.cs
@@ -19,6 +19,10 @@ public class BankTerminal : UdonSharpBehaviour
     public AudioRouter audio;
     public FXRouter fx;
 
+    [Header("SFX/FX IDs")]
+    public int sfxId;
+    public int fxId;
+
     [Header("Bank Storage")]
     int bankResources = 0;
     int bankParts = 0;
@@ -51,8 +55,8 @@ public class BankTerminal : UdonSharpBehaviour
         // Play feedback if something was deposited
         if (depositedResources > 0 || depositedParts > 0)
         {
-            if (audio != null) audio.PlayClip("bank_deposit");
-            if (fx != null) fx.PlayEffect("deposit_glow");
+            if (audio != null) audio.PlayAt(sfxId, transform.position); // AudioRouter.PlayAt(int id, Vector3 pos)
+            if (fx != null) fx.PlayAt(fxId, transform.position); // FXRouter.PlayAt(int id, Vector3 pos)
         }
 
         // Update display
@@ -71,8 +75,8 @@ public class BankTerminal : UdonSharpBehaviour
 
         if (deposited > 0)
         {
-            if (audio != null) audio.PlayClip("bank_deposit");
-            if (fx != null) fx.PlayEffect("deposit_glow");
+            if (audio != null) audio.PlayAt(sfxId, transform.position); // AudioRouter.PlayAt(int id, Vector3 pos)
+            if (fx != null) fx.PlayAt(fxId, transform.position); // FXRouter.PlayAt(int id, Vector3 pos)
         }
 
         UpdateDisplay();
@@ -90,8 +94,8 @@ public class BankTerminal : UdonSharpBehaviour
 
         if (deposited > 0)
         {
-            if (audio != null) audio.PlayClip("bank_deposit");
-            if (fx != null) fx.PlayEffect("deposit_glow");
+            if (audio != null) audio.PlayAt(sfxId, transform.position); // AudioRouter.PlayAt(int id, Vector3 pos)
+            if (fx != null) fx.PlayAt(fxId, transform.position); // FXRouter.PlayAt(int id, Vector3 pos)
         }
 
         UpdateDisplay();

--- a/scripts/World/DropItem.cs
+++ b/scripts/World/DropItem.cs
@@ -31,6 +31,10 @@ public class DropItem : UdonSharpBehaviour
     public AudioRouter audio;
     public FXRouter fx;
 
+    [Header("SFX/FX IDs")]
+    public int sfxId;
+    public int fxId;
+
     public override void Interact()
     {
         CollectItem();
@@ -64,14 +68,14 @@ public class DropItem : UdonSharpBehaviour
         }
 
         // Play feedback effects
-        if (audio != null) audio.PlayClip("item_pickup");
-        if (fx != null) fx.PlayEffect("pickup_glow");
+        if (audio != null) audio.PlayAt(sfxId, transform.position); // AudioRouter.PlayAt(int id, Vector3 pos)
+        if (fx != null) fx.PlayAt(fxId, transform.position); // FXRouter.PlayAt(int id, Vector3 pos)
 
         // Return to pool or disable
         SimpleObjectPool pool = GetComponent<SimpleObjectPool>();
         if (pool != null)
         {
-            pool.ReturnToPool(gameObject);
+            pool.Despawn(gameObject); // SimpleObjectPool.Despawn(GameObject instance)
         }
         else
         {

--- a/scripts/World/TabletController.cs
+++ b/scripts/World/TabletController.cs
@@ -22,6 +22,10 @@ public class TabletController : UdonSharpBehaviour
     public AudioRouter audio;
     public FXRouter fx;
 
+    [Header("SFX/FX IDs")]
+    public int sfxId;
+    public int fxId;
+
     [Header("State")]
     [UdonSynced] public bool hasInitiated = false;
 
@@ -38,7 +42,7 @@ public class TabletController : UdonSharpBehaviour
         var localPlayer = Networking.LocalPlayer;
         if (localPlayer == null) return;
 
-        Networking.SetOwner(gameObject, localPlayer);
+        if (!Networking.IsOwner(gameObject)) Networking.SetOwner(localPlayer, gameObject);
 
         // Set initiated state
         hasInitiated = true;
@@ -47,8 +51,8 @@ public class TabletController : UdonSharpBehaviour
         UpdateVisuals();
 
         // Play feedback
-        if (audio != null) audio.PlayClip("tablet_activate");
-        if (fx != null) fx.PlayEffect("tablet_glow");
+        if (audio != null) audio.PlayAt(sfxId, transform.position); // AudioRouter.PlayAt(int id, Vector3 pos)
+        if (fx != null) fx.PlayAt(fxId, transform.position); // FXRouter.PlayAt(int id, Vector3 pos)
 
         // Sync state
         RequestSerialization();
@@ -63,7 +67,7 @@ public class TabletController : UdonSharpBehaviour
     {
         if (tabletVisual != null)
         {
-            tabletVisual.SetToggleState(!hasInitiated);
+            tabletVisual.Set(!hasInitiated); // NetworkedToggle.Set(bool on)
         }
 
         if (prompt != null)


### PR DESCRIPTION
## Summary
- add the API-first helper guardrail and pre-commit checklist entry to CLAUDE.md
- standardize TabletController, BankTerminal, and DropItem to use AudioRouter/FXRouter PlayAt signatures with serialized IDs and ownership fixes
- align DropTable pooling with SimpleObjectPool.TrySpawn/Despawn and correct EnemySpawner Networking.SetOwner argument order

## Testing
- `rg "Camera\.main" scripts`
- `rg "GetComponent\(typeof" scripts`
- `rg "\[UdonBehaviourSyncMode\(BehaviourSyncMode" scripts`


------
https://chatgpt.com/codex/tasks/task_e_68cf453f5dc88321b5686fc7b509c68d